### PR TITLE
Add Hono backend, memory and blog toggle

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,9 +6,9 @@ import { ThemeProvider } from "@/components/theme-provider"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
+import { ChatBlogLayout } from "@/components/chat-blog-layout"
 import { Zap, MessageSquare, Brain, Shield, Sparkles, ArrowRight, Bot, TrendingUp, Star } from "lucide-react"
 import Link from "next/link"
-import { Chat } from "@/components/chat"
 import { Sidebar } from "@/components/sidebar"
 
 interface User {
@@ -65,7 +65,7 @@ export default function Home() {
           </motion.div>
 
           <div className="flex-1 flex flex-col">
-            <Chat sidebarOpen={sidebarOpen} onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} />
+            <ChatBlogLayout sidebarOpen={sidebarOpen} onToggleSidebar={() => setSidebarOpen(!sidebarOpen)} />
           </div>
         </div>
       </ThemeProvider>

--- a/backend-hono/api/blog.ts
+++ b/backend-hono/api/blog.ts
@@ -1,0 +1,16 @@
+import { Hono } from 'hono'
+import { prisma } from '../../lib/prisma'
+
+const blog = new Hono()
+
+blog.get('/', async c => {
+  try {
+    const posts = await prisma.blogPost.findMany({ orderBy: { createdAt: 'desc' } })
+    return c.json(posts)
+  } catch (error) {
+    console.error('Blog error', error)
+    return c.json({ error: 'failed to fetch posts' }, 500)
+  }
+})
+
+export default blog

--- a/backend-hono/api/chat.ts
+++ b/backend-hono/api/chat.ts
@@ -1,0 +1,42 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { prisma } from '../../lib/prisma'
+import { updateMemoryAndFetchContext } from '../lib/memory-helper'
+
+const chat = new Hono()
+
+const MessageSchema = z.object({
+  userId: z.string(),
+  sessionId: z.string(),
+  content: z.string()
+})
+
+chat.post('/', async c => {
+  try {
+    const { userId, sessionId, content } = MessageSchema.parse(await c.req.json())
+
+    await prisma.message.create({
+      data: {
+        chatSessionId: sessionId,
+        userId,
+        role: 'USER',
+        content
+      }
+    })
+
+    const history = await prisma.message.findMany({
+      where: { chatSessionId: sessionId },
+      orderBy: { createdAt: 'asc' },
+      take: 20
+    })
+
+    const memoryContext = await updateMemoryAndFetchContext(userId, content)
+
+    return c.json({ history, memoryContext })
+  } catch (error) {
+    console.error('Chat error', error)
+    return c.json({ error: 'failed to send message' }, 500)
+  }
+})
+
+export default chat

--- a/backend-hono/api/memory.ts
+++ b/backend-hono/api/memory.ts
@@ -1,0 +1,35 @@
+import { Hono } from 'hono'
+import { z } from 'zod'
+import { updateMemoryAndFetchContext } from '../lib/memory-helper'
+
+const memory = new Hono()
+
+const bodySchema = z.object({
+  userId: z.string(),
+  content: z.string()
+})
+
+memory.post('/', async c => {
+  try {
+    const { userId, content } = bodySchema.parse(await c.req.json())
+    const context = await updateMemoryAndFetchContext(userId, content)
+    return c.json({ success: true, context })
+  } catch (error) {
+    console.error('Memory error', error)
+    return c.json({ success: false, message: 'memory update failed' }, 500)
+  }
+})
+
+memory.get('/:userId', async c => {
+  try {
+    const userId = c.req.param('userId')
+    const query = c.req.query('q') ?? ''
+    const context = await updateMemoryAndFetchContext(userId, query)
+    return c.json({ success: true, context })
+  } catch (error) {
+    console.error('Memory fetch error', error)
+    return c.json({ success: false }, 500)
+  }
+})
+
+export default memory

--- a/backend-hono/lib/memory-helper.ts
+++ b/backend-hono/lib/memory-helper.ts
@@ -1,0 +1,32 @@
+import { Mem0Service } from '../../lib/mem0-service'
+
+const mem0 = new Mem0Service({ apiKey: process.env.MEM0_API_KEY || '' })
+
+const debounceMap = new Map<string, NodeJS.Timeout>()
+
+async function store(userId: string, content: string) {
+  if (debounceMap.has(userId)) {
+    clearTimeout(debounceMap.get(userId)!)
+  }
+  return new Promise<void>(resolve => {
+    const t = setTimeout(async () => {
+      try {
+        await mem0.storeMemory(userId, content, 'chat')
+      } catch (err) {
+        console.error('Mem0 store failed', err)
+      }
+      resolve()
+    }, 300)
+    debounceMap.set(userId, t)
+  })
+}
+
+export async function updateMemoryAndFetchContext(userId: string, content: string) {
+  await store(userId, content)
+  try {
+    return await mem0.retrieveMemories(userId, content, { limit: 5 })
+  } catch (err) {
+    console.error('Mem0 retrieval failed', err)
+    return []
+  }
+}

--- a/backend-hono/server.ts
+++ b/backend-hono/server.ts
@@ -1,0 +1,17 @@
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import { logger } from 'hono/logger'
+import chat from './api/chat'
+import memory from './api/memory'
+import blog from './api/blog'
+
+export const app = new Hono()
+
+app.use('*', logger())
+app.use('*', cors())
+
+app.route('/chat', chat)
+app.route('/memory', memory)
+app.route('/blog', blog)
+
+export default app

--- a/components/blog-panel.tsx
+++ b/components/blog-panel.tsx
@@ -1,0 +1,39 @@
+"use client"
+import { useEffect, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+
+interface BlogPost {
+  id: string
+  title: string
+  content: string
+  tags: string[]
+}
+
+export default function BlogPanel() {
+  const [posts, setPosts] = useState<BlogPost[]>([])
+
+  useEffect(() => {
+    fetch('/api/blog')
+      .then(res => res.json())
+      .then(setPosts)
+      .catch(err => console.error(err))
+  }, [])
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-8">
+      {posts.map(post => (
+        <div key={post.id} className="border-b border-border pb-4">
+          <h2 className="text-lg font-semibold mb-2">{post.title}</h2>
+          <ReactMarkdown className="prose prose-invert max-w-none">{post.content}</ReactMarkdown>
+          <div className="mt-2 space-x-2">
+            {post.tags.map(tag => (
+              <span key={tag} className="text-xs px-2 py-1 bg-muted rounded">
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/chat-blog-layout.tsx
+++ b/components/chat-blog-layout.tsx
@@ -1,0 +1,31 @@
+"use client"
+import { useState } from 'react'
+import { Chat } from './chat'
+import BlogPanel from './blog-panel'
+
+interface Props {
+  sidebarOpen: boolean
+  onToggleSidebar: () => void
+}
+
+export function ChatBlogLayout({ sidebarOpen, onToggleSidebar }: Props) {
+  const [mode, setMode] = useState<'chat' | 'blog'>('chat')
+
+  return (
+    <div className="flex flex-col h-full">
+      {mode === 'chat' ? (
+        <Chat sidebarOpen={sidebarOpen} onToggleSidebar={onToggleSidebar} />
+      ) : (
+        <BlogPanel />
+      )}
+      <div className="p-2 text-center border-t border-border">
+        <button
+          className="text-xs underline text-muted-foreground"
+          onClick={() => setMode(mode === 'chat' ? 'blog' : 'chat')}
+        >
+          {mode === 'chat' ? 'Switch to Blog View' : 'Switch to Chat View'}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "embla-carousel-react": "8.5.1",
         "express": "^5.1.0",
         "framer-motion": "^12.6.3",
+        "hono": "^4.3.0",
         "input-otp": "1.4.1",
         "jsonwebtoken": "^9.0.2",
         "lucide-react": "^0.454.0",
@@ -4682,6 +4683,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.8.3.tgz",
+      "integrity": "sha512-jYZ6ZtfWjzBdh8H/0CIFfCBHaFL75k+KMzaM177hrWWm2TWL39YMYaJgB74uK/niRc866NMlH9B8uCvIo284WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
       }
     },
     "node_modules/html-entities": {

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "hono": "^4.3.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -259,3 +259,21 @@ model RetrievalAnalytics {
 }
 
 
+
+model Memory {
+  id          String   @id @default(cuid())
+  userId      String
+  vectorStoreId String
+  updatedAt   DateTime @updatedAt
+  user        User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  @@map("memories")
+}
+
+model BlogPost {
+  id        String   @id @default(cuid())
+  title     String
+  content   String
+  tags      String[]
+  createdAt DateTime @default(now())
+  @@map("blog_posts")
+}


### PR DESCRIPTION
## Summary
- extend Prisma schema with `Memory` and `BlogPost`
- add standalone Hono backend with chat, memory and blog APIs
- implement debounced memory helper for Mem0
- add blog panel and layout toggle between chat and blog
- update landing page to use new layout
- add `hono` dependency

## Testing
- `npm install --force`
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_685b6b1ad93c832b9d1329ad0fb8d0f1