### PR TITLE
Add Retell websocket endpoint

### DIFF
--- a/backend-hono/api/retell.ts
+++ b/backend-hono/api/retell.ts
@@ -1,0 +1,145 @@
+import { Hono } from 'hono'
+import {
+  defineWebSocketHelper,
+  WSContext,
+} from 'hono/helper/websocket'
+import { MistralService } from '../../lib/mistral-service'
+import {
+  CustomLlmRequest,
+  CustomLlmResponse,
+  Utterance,
+} from '../../lib/retell-types'
+
+const mistral = new MistralService({
+  apiKey: process.env.MISTRAL_API_KEY || '',
+})
+
+const SYSTEM_PROMPT =
+  'You are FinBot, an intelligent banking assistant. Answer user questions clearly and concisely.'
+
+const retell = new Hono()
+
+/**
+ * Convert Retell transcript entries to Mistral chat messages.
+ */
+function toChatMessages(transcript: Utterance[]) {
+  return transcript.map((t) => ({
+    role: t.role === 'agent' ? 'assistant' : t.role,
+    content: t.content,
+  }))
+}
+
+const retellSocket = defineWebSocketHelper<WebSocket>(async (c, events) => {
+  const upgradeHeader = c.req.header('Upgrade')
+  if (upgradeHeader !== 'websocket') {
+    return
+  }
+
+  const pair = new WebSocketPair()
+  const client = pair[0]
+  const server = pair[1]
+
+  const wsContext = new WSContext({
+    raw: server,
+    send: source => server.send(source),
+    close: (code, reason) => server.close(code, reason),
+    get readyState() {
+      return server.readyState
+    },
+    get protocol() {
+      return server.protocol
+    },
+    url: server.url ? new URL(server.url) : null,
+  })
+
+  if (events.onClose) {
+    server.addEventListener('close', evt => events.onClose?.(evt, wsContext))
+  }
+  if (events.onMessage) {
+    server.addEventListener('message', evt => events.onMessage?.(evt, wsContext))
+  }
+  if (events.onError) {
+    server.addEventListener('error', evt => events.onError?.(evt, wsContext))
+  }
+
+  server.accept()
+  events.onOpen?.(new Event('open'), wsContext)
+  return new Response(null, { status: 101, webSocket: client })
+})
+
+retell.get('/llm-websocket/:call_id', retellSocket(c => {
+  const callId = c.req.param('call_id')
+  console.log('Retell websocket connected:', callId)
+
+  const config: CustomLlmResponse = {
+    response_type: 'config',
+    config: { auto_reconnect: true, call_details: true },
+  }
+
+  return {
+    onOpen: (_, ws) => {
+      ws.send(JSON.stringify(config))
+    },
+    async onMessage(evt, ws) {
+      try {
+        const req = JSON.parse(evt.data as string) as CustomLlmRequest
+        if (req.interaction_type === 'ping_pong') {
+          const res: CustomLlmResponse = {
+            response_type: 'ping_pong',
+            timestamp: req.timestamp,
+          }
+          ws.send(JSON.stringify(res))
+          return
+        }
+        if (req.interaction_type === 'call_details') {
+          const res: CustomLlmResponse = {
+            response_type: 'response',
+            response_id: 0,
+            content: 'Hello, how can I assist you today?',
+            content_complete: true,
+          }
+          ws.send(JSON.stringify(res))
+          return
+        }
+        if (
+          req.interaction_type === 'response_required' ||
+          req.interaction_type === 'reminder_required'
+        ) {
+          const messages = [
+            { role: 'system', content: SYSTEM_PROMPT },
+            ...toChatMessages(req.transcript),
+          ]
+          let full = ''
+          for await (const chunk of mistral.streamResponse(messages)) {
+            full += chunk
+            const part: CustomLlmResponse = {
+              response_type: 'response',
+              response_id: req.response_id,
+              content: chunk,
+              content_complete: false,
+            }
+            ws.send(JSON.stringify(part))
+          }
+          const end: CustomLlmResponse = {
+            response_type: 'response',
+            response_id: req.response_id,
+            content: full,
+            content_complete: true,
+          }
+          ws.send(JSON.stringify(end))
+        }
+      } catch (err) {
+        console.error('Retell ws error', err)
+        ws.close(1011, 'server error')
+      }
+    },
+    onClose: () => {
+      console.log('Retell websocket closed:', callId)
+    },
+    onError: evt => {
+      console.error('Retell ws error', evt)
+    },
+  }
+}))
+
+export default retell

--- a/backend-hono/server.ts
+++ b/backend-hono/server.ts
@@ -4,6 +4,7 @@ import { logger } from 'hono/logger'
 import chat from './api/chat'
 import memory from './api/memory'
 import blog from './api/blog'
+import retell from './api/retell'
 
 export const app = new Hono()
 
@@ -13,5 +14,6 @@ app.use('*', cors())
 app.route('/chat', chat)
 app.route('/memory', memory)
 app.route('/blog', blog)
+app.route('/retell', retell)
 
 export default app

--- a/lib/retell-types.ts
+++ b/lib/retell-types.ts
@@ -1,0 +1,100 @@
+export interface Utterance {
+  role: 'agent' | 'user' | 'system'
+  content: string
+}
+
+interface PingPongRequest {
+  interaction_type: 'ping_pong'
+  timestamp: number
+}
+
+interface CallDetailsRequest {
+  interaction_type: 'call_details'
+  call: any
+}
+
+interface UpdateOnlyRequest {
+  interaction_type: 'update_only'
+  transcript: Utterance[]
+  turntaking?: 'agent_turn' | 'user_turn'
+}
+
+export interface ResponseRequiredRequest {
+  interaction_type: 'response_required'
+  transcript: Utterance[]
+  response_id: number
+}
+
+export interface ReminderRequiredRequest {
+  interaction_type: 'reminder_required'
+  transcript: Utterance[]
+  response_id: number
+}
+
+export type CustomLlmRequest =
+  | PingPongRequest
+  | CallDetailsRequest
+  | UpdateOnlyRequest
+  | ResponseRequiredRequest
+  | ReminderRequiredRequest
+
+interface ConfigResponse {
+  response_type: 'config'
+  config: {
+    auto_reconnect: boolean
+    call_details: boolean
+  }
+}
+
+interface PingPongResponse {
+  response_type: 'ping_pong'
+  timestamp: number
+}
+
+interface ToolCallInvocationResponse {
+  response_type: 'tool_call_invocation'
+  tool_call_id: string
+  name: string
+  arguments: string
+}
+
+interface ToolCallResultResponse {
+  response_type: 'tool_call_result'
+  tool_call_id: string
+  content: string
+}
+
+interface ResponseResponse {
+  response_type: 'response'
+  response_id: number
+  content: string
+  content_complete: boolean
+  no_interruption_allowed?: boolean
+  end_call?: boolean
+  transfer_number?: string
+}
+
+interface AgentInterruptResponse {
+  response_type: 'agent_interrupt'
+  interrupt_id: number
+  content: string
+  content_complete: boolean
+  no_interruption_allowed?: boolean
+  end_call?: boolean
+  transfer_number?: string
+}
+
+export type CustomLlmResponse =
+  | ConfigResponse
+  | PingPongResponse
+  | ToolCallInvocationResponse
+  | ToolCallResultResponse
+  | ResponseResponse
+  | AgentInterruptResponse
+
+export interface FunctionCall {
+  id: string
+  funcName: string
+  arguments: Record<string, any>
+  result?: string
+}

--- a/package.json
+++ b/package.json
@@ -78,7 +78,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.6",
     "zod": "^3.24.1",
-    "hono": "^4.3.0"
+    "hono": "^4.3.0",
+    "retell-sdk": "^4.6.0"
   },
   "devDependencies": {
     "@types/node": "^22",

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,0 +1,7 @@
+{
+  "name": "finbot-custom-llm",
+  "main": "./backend-hono/server.ts",
+  "compatibility_date": "2024-11-02",
+  "tsconfig": "./tsconfig.json",
+  "node_compat": true
+}


### PR DESCRIPTION
## Summary
- add `retell-sdk` dependency
- create Retell websocket API using Hono and Mistral
- add Retell route to Hono server
- expose Retell websocket types
- add wrangler config
- refine websocket streaming helper
- update Retell websocket to new helper

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d22b94754832b8482c898a007693a