### PR TITLE
Integrate Inter font and macbook layout

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,7 +8,7 @@
 @tailwind components;
 @tailwind utilities;
 html {
-  font-family: var(--font-inter), sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({
   children: React.ReactNode
 }) {
   return (
-    <html lang="en">
+    <html lang="en" className={inter.variable}>
       <body className={inter.className}>
         <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
           {children}
@@ -30,7 +30,3 @@ export default function RootLayout({
     </html>
   )
 }
-
-
-
-import './globals.css'

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { ChatBlogLayout } from "@/components/chat-blog-layout"
+import { MacBook } from "@/components/macbook"
 import { Zap, MessageSquare, Brain, Shield, Sparkles, ArrowRight, Bot, TrendingUp, Star } from "lucide-react"
 import Link from "next/link"
 import { Sidebar } from "@/components/sidebar"
@@ -263,6 +264,10 @@ export default function Home() {
                 </Button>
               </motion.div>
             </motion.div>
+
+            <MacBook>
+              <img src="/placeholder.jpg" alt="App preview" className="rounded-md" />
+            </MacBook>
 
             {/* Features Grid */}
             <motion.div

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -23,6 +23,7 @@ import {
 } from "lucide-react"
 import { motion, AnimatePresence } from "framer-motion"
 import ReactMarkdown from "react-markdown"
+import { MacBook } from "./macbook"
 
 /* ───────────────────────── types ─────────────────────────── */
 type Role = "user" | "assistant"
@@ -771,7 +772,8 @@ export function Chat({ sidebarOpen, onToggleSidebar }: ChatProps) {
       </AnimatePresence>
 
       {/* Main Chat Area */}
-      <div className="flex flex-col flex-1">
+      <MacBook>
+        <div className="flex flex-col flex-1">
         {/* Header */}
         <motion.header
           className="flex items-center justify-between p-4 border-b border-border bg-background"
@@ -1261,7 +1263,8 @@ export function Chat({ sidebarOpen, onToggleSidebar }: ChatProps) {
             </p>
           </div>
         </motion.div>
-      </div>
+        </div>
+      </MacBook>
     </div>
   )
 }

--- a/components/macbook.tsx
+++ b/components/macbook.tsx
@@ -1,0 +1,15 @@
+import React from "react"
+
+interface MacBookProps {
+  children: React.ReactNode
+}
+
+export function MacBook({ children }: MacBookProps) {
+  return (
+    <div className="relative mx-auto w-full max-w-4xl rounded-2xl bg-gray-800 p-4 shadow-lg">
+      <div className="absolute -top-2 left-1/2 h-2 w-24 -translate-x-1/2 rounded-b-lg bg-gray-700" />
+      <div className="rounded-lg bg-black p-4">{children}</div>
+      <div className="absolute -bottom-2 left-1/2 h-2 w-32 -translate-x-1/2 rounded-b-xl bg-gray-700" />
+    </div>
+  )
+}

--- a/globals.css
+++ b/globals.css
@@ -72,6 +72,6 @@
   }
   body {
     @apply bg-background text-foreground;
-    font-family: var(--font-inter), "Inter", sans-serif;
+    font-family: "Inter", sans-serif;
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -42,7 +42,7 @@ model User {
   bankingProfiles   BankingProfile[]
   
   @@map("users")
-  Memory Memory[]
+  memories Memory[]
 }
 
 model Session {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: 'Inter', sans-serif;
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- ensure Inter font is used throughout styles
- clean up layout and expose font variable
- add simple `MacBook` wrapper component
- showcase MacBook frame on landing page and chat interface
- fix `User` relation naming in Prisma schema

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: prisma not found)*
